### PR TITLE
Forloop last detection in Liquid not working

### DIFF
--- a/_jekyll/search.json
+++ b/_jekyll/search.json
@@ -7,8 +7,7 @@ search: exclude
 [
 {% for page in site.pages %}
 {% unless page.search == "exclude" %}
-{% unless isFirst %},{% endunless %}
-
+{% unless forloop.first %},{% endunless %}
 {
 "title": "{{ page.title | escape }}",
 "tags": "{{ page.tags }}",
@@ -16,7 +15,6 @@ search: exclude
 "url": "{{ page.url | remove: "/"}}",
 "summary": "{{page.summary | strip }}"
 }
-
 {% endunless %}
 {% endfor %}
 ]


### PR DESCRIPTION
Use forloop.first instead as it appears to work more reliably.